### PR TITLE
基本的なコントロールの設置

### DIFF
--- a/HTMLReaderCS/ViewModels/MainWindowViewModel.cs
+++ b/HTMLReaderCS/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,7 @@
-﻿using Prism.Mvvm;
+﻿using HTMLReaderCS.models;
+using Prism.Mvvm;
+using System.IO;
+using System.Text;
 
 namespace HTMLReaderCS.ViewModels
 {
@@ -9,6 +12,12 @@ namespace HTMLReaderCS.ViewModels
         {
             get { return _title; }
             set { SetProperty(ref _title, value); }
+        }
+
+        private HTMLContents htmlContents;
+        public HTMLContents HtmlContents {
+            get => htmlContents;
+            set => SetProperty(ref htmlContents, value);
         }
 
         public MainWindowViewModel()

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -8,8 +8,53 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         prism:ViewModelLocator.AutoWireViewModel="True"
-        Title="{Binding Title}" Height="350" Width="525">
+        Title="{Binding Title}" Height="600" Width="800">
     <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
         <ContentControl prism:RegionManager.RegionName="ContentRegion" />
+
+        <ListView ItemsSource="{Binding HtmlContents.TextElements}"
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                  Grid.Column="1"
+                  >
+
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="BorderThickness" Value="1"/>
+                    <Setter Property="BorderBrush" Value="LightGray"/>
+                </Style>
+            </ListView.ItemContainerStyle>
+
+            <ListView.View>
+                <GridView>
+                    <GridView.Columns>
+
+                        <GridViewColumn DisplayMemberBinding="{Binding TagName}"
+                                        Header="タグ"
+                                        />
+                        <GridViewColumn Header="本文">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="LightGray"
+                                            BorderThickness="1,0,0,0"
+                                            >
+                                        <TextBlock Text="{Binding TextContent}"
+                                                   TextWrapping="Wrap"
+                                                   Padding="4,0,0,0"
+                                                   />
+                                    </Border>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+
+                    </GridView.Columns>
+                    
+                </GridView>
+            </ListView.View>
+        </ListView>
+
     </Grid>
 </Window>

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -2,6 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:prism="http://prismlibrary.com/"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        d:DataContext="{d:DesignInstance local:MainWindowViewModel, IsDesignTimeCreatable=True}"
+        xmlns:local="clr-namespace:HTMLReaderCS.ViewModels"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
         prism:ViewModelLocator.AutoWireViewModel="True"
         Title="{Binding Title}" Height="350" Width="525">
     <Grid>

--- a/HTMLReaderCS/models/HTMLContents.cs
+++ b/HTMLReaderCS/models/HTMLContents.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace HTMLReaderCS.models {
-    class HTMLContents {
+    public class HTMLContents {
 
         private IHtmlDocument htmlDocument;
 


### PR DESCRIPTION
- Xamlエディタでデータコンテキストに関する補完が有効になるようコードを追加
- クラスをMainWindowで公開する際、アクセスレベルの設定ミスでエラーの状態だったので修正
- MainWindowViewModel に、HTMLContents をプロパティとして追加
- UI変更 / MainWindow に、カスタムしたListView を追加

close #3
