### PR TITLE
20210417#19 出力ファイルの履歴機能の実装

### DIFF
--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -107,6 +107,9 @@
       <Version>3.7.0.9</Version>
     </PackageReference>
     <PackageReference Include="Prism.Unity" Version="7.2.0.1422" />
+    <PackageReference Include="System.Data.SQLite.Core">
+      <Version>1.0.113.7</Version>
+    </PackageReference>
     <PackageReference Include="System.Text.Encoding.CodePages">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -68,6 +68,7 @@
     <Compile Include="models\HTMLContents.cs" />
     <Compile Include="models\HTMLPlayer.cs" />
     <Compile Include="models\ITalker.cs" />
+    <Compile Include="models\OutputFileInfo.cs" />
     <Compile Include="models\PollyPlayer.cs" />
     <Compile Include="models\SQLiteHelper.cs" />
     <Compile Include="models\SSMLConverter.cs" />

--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -69,6 +69,7 @@
     <Compile Include="models\HTMLPlayer.cs" />
     <Compile Include="models\ITalker.cs" />
     <Compile Include="models\PollyPlayer.cs" />
+    <Compile Include="models\SQLiteHelper.cs" />
     <Compile Include="models\SSMLConverter.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />
     <Compile Include="Views\MainWindow.xaml.cs">

--- a/HTMLReaderCS/models/HTMLPlayer.cs
+++ b/HTMLReaderCS/models/HTMLPlayer.cs
@@ -125,12 +125,7 @@ namespace HTMLReaderCS.models
                     outputFileInfo.HeaderText = PlayingPlainText.Substring(0, Math.Min(50,PlayingPlainText.Length));
                     outputFileInfo.OutputDateTime = DateTime.Now;
                     outputFileInfo.TagName = SelectedItem.TextElements[PlayingIndex].TagName;
-
-                    PollyPlayer pp = talker as PollyPlayer;
-
-                    if(pp != null) {
-                        outputFileInfo.FileName = pp.LastOutputFileName;
-                    }
+                    outputFileInfo.FileName = talker.OutputFileName;
                 }
             ));
         }

--- a/HTMLReaderCS/models/HTMLPlayer.cs
+++ b/HTMLReaderCS/models/HTMLPlayer.cs
@@ -3,6 +3,7 @@ using Prism.Mvvm;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -28,6 +29,10 @@ namespace HTMLReaderCS.models
         private int PlayingIndex { get; set; } = 0;
         public String PlayingPlainText { get; private set; } = "";
 
+        private OutputFileInfo outputFileInfo;
+        private SQLiteHelper sqLiteHelper = new SQLiteHelper();
+        private Stopwatch stopwatch = new Stopwatch();
+
         public HTMLContents SelectedItem { 
             get => selectedItem;
             set {
@@ -49,6 +54,10 @@ namespace HTMLReaderCS.models
         public HTMLPlayer(ITalker talker) {
             this.talker = talker;
             this.talker.TalkEnded += (sender, e) => {
+                stopwatch.Stop();
+                outputFileInfo.LengthSec = (int)stopwatch.Elapsed.TotalSeconds;
+                sqLiteHelper.insert(outputFileInfo);
+
                 PlayingIndex++;
                 PlayCommand.Execute();
             };
@@ -110,6 +119,18 @@ namespace HTMLReaderCS.models
                     }
                     converter.Text = PlayingPlainText;
                     talker.ssmlTalk(converter.getSSML());
+
+                    stopwatch.Start();
+                    outputFileInfo = new OutputFileInfo();
+                    outputFileInfo.HeaderText = PlayingPlainText.Substring(0, Math.Min(50,PlayingPlainText.Length));
+                    outputFileInfo.OutputDateTime = DateTime.Now;
+                    outputFileInfo.TagName = SelectedItem.TextElements[PlayingIndex].TagName;
+
+                    PollyPlayer pp = talker as PollyPlayer;
+
+                    if(pp != null) {
+                        outputFileInfo.FileName = pp.LastOutputFileName;
+                    }
                 }
             ));
         }

--- a/HTMLReaderCS/models/HTMLPlayer.cs
+++ b/HTMLReaderCS/models/HTMLPlayer.cs
@@ -129,6 +129,7 @@ namespace HTMLReaderCS.models
                     outputFileInfo.OutputDateTime = DateTime.Now;
                     outputFileInfo.TagName = SelectedItem.TextElements[PlayingIndex].TagName;
                     outputFileInfo.FileName = talker.OutputFileName;
+                    outputFileInfo.HtmlFileName = SelectedItem.FileName;
                 }
             ));
         }

--- a/HTMLReaderCS/models/HTMLPlayer.cs
+++ b/HTMLReaderCS/models/HTMLPlayer.cs
@@ -54,8 +54,11 @@ namespace HTMLReaderCS.models
         public HTMLPlayer(ITalker talker) {
             this.talker = talker;
             this.talker.TalkEnded += (sender, e) => {
+
                 stopwatch.Stop();
                 outputFileInfo.LengthSec = (int)stopwatch.Elapsed.TotalSeconds;
+                stopwatch.Reset();
+
                 sqLiteHelper.insert(outputFileInfo);
 
                 PlayingIndex++;

--- a/HTMLReaderCS/models/ITalker.cs
+++ b/HTMLReaderCS/models/ITalker.cs
@@ -23,5 +23,7 @@ namespace HTMLReaderCS.models
         event EventHandler TalkEnded;
 
         void stop();
+
+        string OutputFileName { get; }
     }
 }

--- a/HTMLReaderCS/models/OutputFileInfo.cs
+++ b/HTMLReaderCS/models/OutputFileInfo.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HTMLReaderCS.models {
+    public class OutputFileInfo {
+
+        public int LengthSec { get; set; }
+        public string FileName { get; set; }
+        public string HtmlFileName { get; set; }
+        public string HeaderText { get; set; }
+        public string TagName { get; set; }
+        public DateTime OutputDateTime { get; set; }
+
+    }
+}

--- a/HTMLReaderCS/models/PollyPlayer.cs
+++ b/HTMLReaderCS/models/PollyPlayer.cs
@@ -15,6 +15,8 @@ namespace HTMLReaderCS.models {
 
         public SSMLConverter SsmlConverter { get; set; } = new SSMLConverter();
 
+        public string LastOutputFileName { get; set; }
+
         private DirectoryInfo OutputDirectoryInfo { get; set; } = new DirectoryInfo("outputs");
 
         private AmazonPollyClient PollyClient { get; set; }
@@ -73,8 +75,8 @@ namespace HTMLReaderCS.models {
 
             var stream = response.AudioStream;
 
-            var outputFileName = DateTime.Now.ToString("yyyyMMddHHmmssff");
-            var filePath = $"{OutputDirectoryInfo.Name}\\{outputFileName}.mp3";
+            LastOutputFileName = DateTime.Now.ToString("yyyyMMddHHmmssff");
+            var filePath = $"{OutputDirectoryInfo.Name}\\{LastOutputFileName}.mp3";
 
             using (var output = new FileStream(filePath, FileMode.Create)) {
                 stream.CopyTo(output);

--- a/HTMLReaderCS/models/PollyPlayer.cs
+++ b/HTMLReaderCS/models/PollyPlayer.cs
@@ -15,7 +15,10 @@ namespace HTMLReaderCS.models {
 
         public SSMLConverter SsmlConverter { get; set; } = new SSMLConverter();
 
-        public string LastOutputFileName { get; set; }
+        /// <summary>
+        /// 最後に読み上げた音声ファイル名を取得します。
+        /// </summary>
+        public string OutputFileName { get; private set; }
 
         private DirectoryInfo OutputDirectoryInfo { get; set; } = new DirectoryInfo("outputs");
 
@@ -75,8 +78,8 @@ namespace HTMLReaderCS.models {
 
             var stream = response.AudioStream;
 
-            LastOutputFileName = DateTime.Now.ToString("yyyyMMddHHmmssff");
-            var filePath = $"{OutputDirectoryInfo.Name}\\{LastOutputFileName}.mp3";
+            OutputFileName = $"{DateTime.Now.ToString("yyyyMMddHHmmssff")}.mp3";
+            var filePath = $"{OutputDirectoryInfo.Name}\\{OutputFileName}";
 
             using (var output = new FileStream(filePath, FileMode.Create)) {
                 stream.CopyTo(output);

--- a/HTMLReaderCS/models/SQLiteHelper.cs
+++ b/HTMLReaderCS/models/SQLiteHelper.cs
@@ -11,7 +11,6 @@ namespace HTMLReaderCS.models {
         public string DBFileName => "OutputHistory.sqlite";
         public string TableName => "output_history";
 
-        private SQLiteConnectionStringBuilder SQLiteConnectionStringBuilder { get; set; }
         private SQLiteConnection Connection {
             get {
                 var sqliteSb = new SQLiteConnectionStringBuilder() { DataSource = DBFileName };
@@ -22,13 +21,13 @@ namespace HTMLReaderCS.models {
         public SQLiteHelper() {
             executeNonQuer(
                 $"CREATE TABLE IF NOT EXISTS {TableName} (" +
-                $"id                INTEGER NOT NULL PRIMARY KEY, " +
-                $"lengthSec         INTEGER NOT NULL, " +
-                $"fileName          TEXT NOT NULL, " +
-                $"outputDateTime    TEXT NOT NULL, " +
-                $"htmlFileName      TEXT NOT NULL, " +
-                $"tagName           TEXT NOT NULL, " +
-                $"headerText        TEXT NOT NULL" +
+                $"id                                         INTEGER NOT NULL PRIMARY KEY, " +
+                $"{nameof(OutputFileInfo.LengthSec)}         INTEGER NOT NULL, " +
+                $"{nameof(OutputFileInfo.FileName)}          TEXT NOT NULL, " +
+                $"{nameof(OutputFileInfo.OutputDateTime)}    TEXT NOT NULL, " +
+                $"{nameof(OutputFileInfo.HtmlFileName)}      TEXT NOT NULL, " +
+                $"{nameof(OutputFileInfo.TagName)}           TEXT NOT NULL, " +
+                $"{nameof(OutputFileInfo.HeaderText)}        TEXT NOT NULL" +
                 $");"
             );
         }

--- a/HTMLReaderCS/models/SQLiteHelper.cs
+++ b/HTMLReaderCS/models/SQLiteHelper.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HTMLReaderCS.models {
+    public class SQLiteHelper {
+
+        public string DBFileName => "OutputHistory.sqlite";
+        public string TableName => "output_history";
+
+        private SQLiteConnectionStringBuilder SQLiteConnectionStringBuilder { get; set; }
+        private SQLiteConnection Connection {
+            get {
+                var sqliteSb = new SQLiteConnectionStringBuilder() { DataSource = DBFileName };
+                return new SQLiteConnection(sqliteSb.ToString());
+            }
+        }
+
+        public SQLiteHelper() {
+            executeNonQuer(
+                $"CREATE TABLE IF NOT EXISTS {TableName} (" +
+                $"id                INTEGER NOT NULL PRIMARY KEY, " +
+                $"lengthSec         INTEGER NOT NULL, " +
+                $"fileName          TEXT NOT NULL, " +
+                $"outputDateTime    TEXT NOT NULL, " +
+                $"htmlFileName      TEXT NOT NULL, " +
+                $"tagName           TEXT NOT NULL, " +
+                $"headerText        TEXT NOT NULL" +
+                $");"
+            );
+        }
+
+        private void executeNonQuer(string sql) {
+            using (var con = Connection) {
+                con.Open();
+                using (var command = new SQLiteCommand(con)) {
+                    command.CommandText = sql;
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+    }
+}

--- a/HTMLReaderCS/models/SQLiteHelper.cs
+++ b/HTMLReaderCS/models/SQLiteHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data.SQLite;
 using System.Linq;
@@ -32,6 +33,52 @@ namespace HTMLReaderCS.models {
             );
         }
 
+        public void insert(OutputFileInfo outputFileInfo) {
+            var count = getCount() + 1;
+            executeNonQuer($"INSERT INTO {TableName}(" +
+                $"id," +
+                $"{nameof(OutputFileInfo.LengthSec)}," +
+                $"{nameof(OutputFileInfo.FileName)}," +
+                $"{nameof(OutputFileInfo.OutputDateTime)}," +
+                $"{nameof(OutputFileInfo.HtmlFileName)}," +
+                $"{nameof(OutputFileInfo.TagName)}," +
+                $"{nameof(OutputFileInfo.HeaderText)}" +
+                $") VALUES (" +
+                $"{count}, " + 
+                $"{outputFileInfo.LengthSec}," +
+                $"'{outputFileInfo.FileName}'," +
+                $"'{outputFileInfo.OutputDateTime}'," +
+                $"'{outputFileInfo.HtmlFileName}'," +
+                $"'{outputFileInfo.TagName}'," +
+                $"'{outputFileInfo.HeaderText}'" +
+                $");"
+            );
+        }
+
+        public long getCount() {
+            return (long)select($"SELECT COUNT(*) FROM {TableName};").First()["COUNT(*)"];
+        }
+
+        public List<Hashtable> select(string sql) {
+            using (var con = Connection) {
+                List<Hashtable> resultList = new List<Hashtable>();
+                con.Open();
+                var command = new SQLiteCommand(sql, con);
+                var dataReader = command.ExecuteReader();
+
+                while (dataReader.Read()) {
+                    var hashtable = new Hashtable();
+                    for (int i = 0; i < dataReader.FieldCount; i++) {
+                        hashtable[dataReader.GetName(i)] = dataReader.GetValue(i);
+                    }
+                    resultList.Add(hashtable);
+                }
+
+                dataReader.Close();
+                return resultList;
+            };
+        }
+
         private void executeNonQuer(string sql) {
             using (var con = Connection) {
                 con.Open();
@@ -41,6 +88,5 @@ namespace HTMLReaderCS.models {
                 }
             }
         }
-
     }
 }

--- a/HTMLReaderCSTests/HTMLReaderCSTests.csproj
+++ b/HTMLReaderCSTests/HTMLReaderCSTests.csproj
@@ -47,6 +47,9 @@
     </Reference>
     <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59" />
     <Reference Include="System" />
+    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -60,6 +63,7 @@
     <Compile Include="models\DummyTalker.cs" />
     <Compile Include="models\HTMLPlayerTests.cs" />
     <Compile Include="models\PollyPlayerTests.cs" />
+    <Compile Include="models\SQLiteHelperTests.cs" />
     <Compile Include="models\SSMLConverterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -98,8 +102,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/HTMLReaderCSTests/models/SQLiteHelperTests.cs
+++ b/HTMLReaderCSTests/models/SQLiteHelperTests.cs
@@ -13,5 +13,17 @@ namespace HTMLReaderCS.models.Tests {
         public void SQLiteHelperTest() {
             var SQLiteHelper = new SQLiteHelper();
         }
+
+        [TestMethod()]
+        public void insertTest() {
+            var sqliteHelper = new SQLiteHelper();
+            sqliteHelper.insert(new OutputFileInfo());
+        }
+
+        [TestMethod()]
+        public void selectTest() {
+            var sqliteHelper = new SQLiteHelper();
+            var l = sqliteHelper.select($"select * from {sqliteHelper.TableName};");
+        }
     }
 }

--- a/HTMLReaderCSTests/models/SQLiteHelperTests.cs
+++ b/HTMLReaderCSTests/models/SQLiteHelperTests.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HTMLReaderCS.models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HTMLReaderCS.models.Tests {
+    [TestClass()]
+    public class SQLiteHelperTests {
+        [TestMethod()]
+        public void SQLiteHelperTest() {
+            var SQLiteHelper = new SQLiteHelper();
+        }
+    }
+}

--- a/HTMLReaderCSTests/packages.config
+++ b/HTMLReaderCSTests/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net472" />
+  <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.113.3" targetFramework="net472" />
+  <package id="System.Data.SQLite.Core" version="1.0.113.7" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- パッケージ追加 / System.Data.SQLite.Core を追加
- 暫定的なテーブルを作成するところまで実装
- クラス追加 / 出力履歴を表すクラスを追加
- 機能追加 / DBへのレコードの挿入と取得メソッドを実装
- 機能追加 / 出力したファイルの履歴をデータベースに残すよう実装
- Italker に出力ファイル名を取得するプロパティを追加
- 修正 / stopwatch のリセットを忘れていたので修正
- 読み上げたHTMLファイル名も記録するよう実装

close #19
