### PR TITLE
出力ファイルの履歴機能

### DIFF
--- a/HTMLReaderCS/App.xaml.cs
+++ b/HTMLReaderCS/App.xaml.cs
@@ -2,6 +2,7 @@
 using Prism.Ioc;
 using Prism.Modularity;
 using System.Windows;
+using HTMLReaderCS.ViewModels;
 
 namespace HTMLReaderCS
 {
@@ -17,7 +18,7 @@ namespace HTMLReaderCS
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
         {
-
+            containerRegistry.RegisterDialog<HistoryWindow, HistoryWindowViewModel>();
         }
     }
 }

--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -56,6 +56,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Views\HistoryWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -72,7 +76,11 @@
     <Compile Include="models\PollyPlayer.cs" />
     <Compile Include="models\SQLiteHelper.cs" />
     <Compile Include="models\SSMLConverter.cs" />
+    <Compile Include="ViewModels\HistoryWindowViewModel.cs" />
     <Compile Include="ViewModels\MainWindowViewModel.cs" />
+    <Compile Include="Views\HistoryWindow.xaml.cs">
+      <DependentUpon>HistoryWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -68,6 +68,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="models\DateTimeConverter.cs" />
     <Compile Include="models\DropBehavior.cs" />
     <Compile Include="models\HTMLContents.cs" />
     <Compile Include="models\HTMLPlayer.cs" />

--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="models\DateTimeConverter.cs" />
     <Compile Include="models\DropBehavior.cs" />
+    <Compile Include="models\HeaderTextConverter.cs" />
     <Compile Include="models\HTMLContents.cs" />
     <Compile Include="models\HTMLPlayer.cs" />
     <Compile Include="models\ITalker.cs" />

--- a/HTMLReaderCS/ViewModels/HistoryWindowViewModel.cs
+++ b/HTMLReaderCS/ViewModels/HistoryWindowViewModel.cs
@@ -1,0 +1,33 @@
+﻿using Prism.Commands;
+using Prism.Services.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HTMLReaderCS.ViewModels {
+    class HistoryWindowViewModel : IDialogAware {
+        public string Title => "履歴";
+
+        public event Action<IDialogResult> RequestClose;
+
+        public bool CanCloseDialog() => true;
+
+        public void OnDialogClosed() {
+        }
+
+        public void OnDialogOpened(IDialogParameters parameters) {
+        }
+
+        public DelegateCommand CloseWindowCommand {
+            #region
+            get => closeWindowCommand ?? (closeWindowCommand = new DelegateCommand(() => {
+                RequestClose?.Invoke(new DialogResult());
+            }));
+        }
+        private DelegateCommand closeWindowCommand;
+        #endregion
+
+    }
+}

--- a/HTMLReaderCS/ViewModels/HistoryWindowViewModel.cs
+++ b/HTMLReaderCS/ViewModels/HistoryWindowViewModel.cs
@@ -1,4 +1,6 @@
-﻿using Prism.Commands;
+﻿using HTMLReaderCS.models;
+using Prism.Commands;
+using Prism.Mvvm;
 using Prism.Services.Dialogs;
 using System;
 using System.Collections.Generic;
@@ -7,10 +9,15 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace HTMLReaderCS.ViewModels {
-    class HistoryWindowViewModel : IDialogAware {
+    class HistoryWindowViewModel : BindableBase, IDialogAware {
         public string Title => "履歴";
 
         public event Action<IDialogResult> RequestClose;
+
+        private SQLiteHelper SQLiteHelper { get; set; }
+
+        public List<OutputFileInfo> OutputHistory { get => outputHistory; set => SetProperty(ref outputHistory, value); }
+        private List<OutputFileInfo> outputHistory;
 
         public bool CanCloseDialog() => true;
 
@@ -18,6 +25,8 @@ namespace HTMLReaderCS.ViewModels {
         }
 
         public void OnDialogOpened(IDialogParameters parameters) {
+            SQLiteHelper = new SQLiteHelper();
+            OutputHistory = SQLiteHelper.getHistories();
         }
 
         public DelegateCommand CloseWindowCommand {

--- a/HTMLReaderCS/ViewModels/MainWindowViewModel.cs
+++ b/HTMLReaderCS/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using HTMLReaderCS.models;
+using HTMLReaderCS.Views;
 using Prism.Commands;
 using Prism.Mvvm;
+using Prism.Services.Dialogs;
 using System.IO;
 using System.Text;
 
@@ -22,10 +24,12 @@ namespace HTMLReaderCS.ViewModels
             set => SetProperty(ref htmlPlayer, value);
         }
 
-        public MainWindowViewModel() {
+        private IDialogService dialogService;
+
+        public MainWindowViewModel(IDialogService _dialogService) {
+            dialogService = _dialogService;
             HTMLPlayer = new HTMLPlayer(new PollyPlayer());
         }
-
 
         public DelegateCommand ResetFileListCommand {
             #region
@@ -34,6 +38,17 @@ namespace HTMLReaderCS.ViewModels
             }));
         }
         private DelegateCommand resetFileListCommand;
+        #endregion
+
+
+        public DelegateCommand ShowHistoryWindowCommand {
+            #region
+            get => showHistoryWindowCommand ?? (showHistoryWindowCommand = new DelegateCommand(() => {
+                dialogService.ShowDialog(nameof(HistoryWindow), new DialogParameters(), (IDialogResult result) => {
+                });
+            }));
+        }
+        private DelegateCommand showHistoryWindowCommand;
         #endregion
 
     }

--- a/HTMLReaderCS/Views/HistoryWindow.xaml
+++ b/HTMLReaderCS/Views/HistoryWindow.xaml
@@ -5,11 +5,15 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:HTMLReaderCS.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="clr-namespace:HTMLReaderCS.Models"
     xmlns:prism="http://prismlibrary.com/"
     Width="600"
     Height="450"
     prism:ViewModelLocator.AutoWireViewModel="True"
     mc:Ignorable="d">
+    <UserControl.Resources>
+        <models:DateTimeConverter x:Key="DateTimeConverter" />
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
@@ -25,7 +29,7 @@
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">
 
-                        <TextBlock Width="200" Text="{Binding FileName}" />
+                        <TextBlock Width="150" Text="{Binding FileName}" />
 
                         <Border Width="1" Background="Black" />
 
@@ -43,11 +47,15 @@
 
                         <Border Width="1" Background="Black" />
 
-                        <TextBlock Width="100" Text="{Binding HeaderText}" />
+                        <TextBlock Width="120" Text="{Binding HeaderText}" />
 
                         <Border Width="1" Background="Black" />
 
-                        <TextBlock Width="100" Text="{Binding OutputDateTime}" />
+                        <TextBlock
+                            Width="120"
+                            Text="{Binding OutputDateTime, Converter={StaticResource DateTimeConverter}}"
+                            TextAlignment="Center" />
+
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/HTMLReaderCS/Views/HistoryWindow.xaml
+++ b/HTMLReaderCS/Views/HistoryWindow.xaml
@@ -11,9 +11,12 @@
     Height="450"
     prism:ViewModelLocator.AutoWireViewModel="True"
     mc:Ignorable="d">
+
     <UserControl.Resources>
         <models:DateTimeConverter x:Key="DateTimeConverter" />
+        <models:HeaderTextConverter x:Key="HeaderTextConverter" />
     </UserControl.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
@@ -47,7 +50,10 @@
 
                         <Border Width="1" Background="Black" />
 
-                        <TextBlock Width="120" Text="{Binding HeaderText}" />
+                        <TextBlock
+                            Width="220"
+                            Padding="5,0"
+                            Text="{Binding HeaderText, Converter={StaticResource HeaderTextConverter}}" />
 
                         <Border Width="1" Background="Black" />
 

--- a/HTMLReaderCS/Views/HistoryWindow.xaml
+++ b/HTMLReaderCS/Views/HistoryWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:HTMLReaderCS.Models"
     xmlns:prism="http://prismlibrary.com/"
-    Width="600"
+    Width="800"
     Height="450"
     prism:ViewModelLocator.AutoWireViewModel="True"
     mc:Ignorable="d">
@@ -51,7 +51,7 @@
                         <Border Width="1" Background="Black" />
 
                         <TextBlock
-                            Width="220"
+                            Width="280"
                             Padding="5,0"
                             Text="{Binding HeaderText, Converter={StaticResource HeaderTextConverter}}" />
 
@@ -61,6 +61,13 @@
                             Width="120"
                             Text="{Binding OutputDateTime, Converter={StaticResource DateTimeConverter}}"
                             TextAlignment="Center" />
+
+                        <Border Width="1" Background="Black" />
+
+                        <TextBlock
+                            Width="80"
+                            Padding="5,0"
+                            Text="{Binding HtmlFileName}" />
 
                     </StackPanel>
                 </DataTemplate>

--- a/HTMLReaderCS/Views/HistoryWindow.xaml
+++ b/HTMLReaderCS/Views/HistoryWindow.xaml
@@ -6,11 +6,51 @@
     xmlns:local="clr-namespace:HTMLReaderCS.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:prism="http://prismlibrary.com/"
-    d:DesignHeight="450"
-    d:DesignWidth="800"
+    Width="600"
+    Height="450"
     prism:ViewModelLocator.AutoWireViewModel="True"
     mc:Ignorable="d">
     <Grid>
-        <Button Command="{Binding CloseWindowCommand}" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <Button
+            Grid.Row="0"
+            Command="{Binding CloseWindowCommand}"
+            Content="ウィンドウを閉じる" />
+        <ListBox Grid.Row="1" ItemsSource="{Binding OutputHistory}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+
+                        <TextBlock Width="200" Text="{Binding FileName}" />
+
+                        <Border Width="1" Background="Black" />
+
+                        <TextBlock
+                            Width="30"
+                            Text="{Binding LengthSec}"
+                            TextAlignment="Center" />
+
+                        <Border Width="1" Background="Black" />
+
+                        <TextBlock
+                            Width="50"
+                            Text="{Binding TagName}"
+                            TextAlignment="Center" />
+
+                        <Border Width="1" Background="Black" />
+
+                        <TextBlock Width="100" Text="{Binding HeaderText}" />
+
+                        <Border Width="1" Background="Black" />
+
+                        <TextBlock Width="100" Text="{Binding OutputDateTime}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
     </Grid>
 </UserControl>

--- a/HTMLReaderCS/Views/HistoryWindow.xaml
+++ b/HTMLReaderCS/Views/HistoryWindow.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+    x:Class="HTMLReaderCS.Views.HistoryWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:HTMLReaderCS.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:prism="http://prismlibrary.com/"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    prism:ViewModelLocator.AutoWireViewModel="True"
+    mc:Ignorable="d">
+    <Grid>
+        <Button Command="{Binding CloseWindowCommand}" />
+    </Grid>
+</UserControl>

--- a/HTMLReaderCS/Views/HistoryWindow.xaml.cs
+++ b/HTMLReaderCS/Views/HistoryWindow.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace HTMLReaderCS.Views {
+    /// <summary>
+    /// HistoryWindow.xaml の相互作用ロジック
+    /// </summary>
+    public partial class HistoryWindow : UserControl {
+        public HistoryWindow() {
+            InitializeComponent();
+        }
+    }
+}

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -41,6 +41,10 @@
             <MenuItem Header="ファイル">
                 <MenuItem Command="{Binding ResetFileListCommand}" Header="ファイルリストをリセット" />
             </MenuItem>
+
+            <MenuItem Header="表示">
+                <MenuItem Command="{Binding ShowHistoryWindowCommand}" Header="履歴ウィンドウ" />
+            </MenuItem>
         </Menu>
 
         <Grid

--- a/HTMLReaderCS/models/DateTimeConverter.cs
+++ b/HTMLReaderCS/models/DateTimeConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Windows.Data;
+using System.Globalization;
+
+namespace HTMLReaderCS.Models {
+    class DateTimeConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            DateTime dateTime = (DateTime)value;
+            return dateTime.ToString("yyyy/MM/dd HH:mm:ss");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/HTMLReaderCS/models/HeaderTextConverter.cs
+++ b/HTMLReaderCS/models/HeaderTextConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace HTMLReaderCS.Models {
+    class HeaderTextConverter : IValueConverter {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+
+            // 表示されるテキストから改行文字を取り除きます。
+
+            var text = (string)value;
+            return text.Replace("\r", "").Replace("\n", "");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/HTMLReaderCS/models/SQLiteHelper.cs
+++ b/HTMLReaderCS/models/SQLiteHelper.cs
@@ -79,6 +79,24 @@ namespace HTMLReaderCS.models {
             };
         }
 
+        public List<OutputFileInfo> getHistories() {
+            var list = new List<OutputFileInfo>();
+            var hashs = select($"SELECT * FROM {TableName} ORDER BY {nameof(OutputFileInfo.OutputDateTime)};");
+            foreach(var h in hashs) {
+                var outputFileInfo = new OutputFileInfo();
+                outputFileInfo.FileName = (string)h[nameof(outputFileInfo.FileName)];
+                outputFileInfo.HeaderText = (string)h[nameof(outputFileInfo.HeaderText)];
+                outputFileInfo.HtmlFileName = (string)h[nameof(outputFileInfo.HtmlFileName)];
+                outputFileInfo.TagName = (string)h[nameof(outputFileInfo.TagName)];
+                outputFileInfo.LengthSec = (int)(long)h[nameof(outputFileInfo.LengthSec)];
+                outputFileInfo.OutputDateTime = DateTime.Parse((string)h[nameof(outputFileInfo.OutputDateTime)]);
+
+                list.Add(outputFileInfo);
+            }
+
+            return list;
+        }
+
         private void executeNonQuer(string sql) {
             using (var con = Connection) {
                 con.Open();

--- a/HTMLReaderCSTests/models/DummyTalker.cs
+++ b/HTMLReaderCSTests/models/DummyTalker.cs
@@ -13,6 +13,8 @@ namespace HTMLReaderCSTests.models
 
         public String PlayingText { get; set; }
 
+        public string OutputFileName { get; }
+
         public void ssmlTalk(string ssmlText) {
             PlayingText = ssmlText;
         }

--- a/HTMLReaderCSTests/models/SQLiteHelperTests.cs
+++ b/HTMLReaderCSTests/models/SQLiteHelperTests.cs
@@ -25,5 +25,11 @@ namespace HTMLReaderCS.models.Tests {
             var sqliteHelper = new SQLiteHelper();
             var l = sqliteHelper.select($"select * from {sqliteHelper.TableName};");
         }
+
+        [TestMethod()]
+        public void getHistoriesTest() {
+            var sqliteHelper = new SQLiteHelper();
+            var l = sqliteHelper.getHistories();
+        }
     }
 }


### PR DESCRIPTION
- 履歴閲覧のためのウィンドウを追加
- 機能追加 / データベースから出力履歴を取得する機能を実装
- 履歴ウィンドウに ListBox を追加し、履歴を閲覧できるところまで実装
- ログ表示用に DateTime の コンバーターを追加
- ヘッダーテキストから改行を取り除くコンバーターを追加、実装
- 履歴の表示項目に HTMLファイル名を追加

close #21
