### PR TITLE
20210517#33 ステータスバーの機能拡張

### DIFF
--- a/HTMLReaderCS/HTMLReaderCS.csproj
+++ b/HTMLReaderCS/HTMLReaderCS.csproj
@@ -95,6 +95,7 @@
     <Compile Include="models\HeaderTextConverter.cs" />
     <Compile Include="models\HTMLContents.cs" />
     <Compile Include="models\IPlayer.cs" />
+    <Compile Include="models\TextBoxNumericBehavior.cs" />
     <Compile Include="models\TextPlayer.cs" />
     <Compile Include="models\HTMLPlayer.cs" />
     <Compile Include="models\ITalker.cs" />

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -87,6 +87,7 @@
 
                 <TextBox
                     Width="50"
+                    modesl:TextBoxNumericBehavior.IsNumeric="True"
                     Text="{Binding Player.SelectedTextIndex}"
                     TextAlignment="Center" />
 

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -29,6 +29,7 @@
 
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
 
@@ -50,51 +51,56 @@
         <Grid
             Grid.Row="1"
             Grid.Column="0"
-            VerticalAlignment="Top">
+            Grid.ColumnSpan="2">
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="auto" />
+                <RowDefinition />
                 <RowDefinition />
             </Grid.RowDefinitions>
 
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Row="0" Orientation="Horizontal">
 
-            <Button
-                Grid.Row="0"
-                Grid.Column="0"
-                Command="{Binding Player.PlayCommand}"
-                Content="再生" />
+                <Button
+                    Width="80"
+                    Margin="3,1"
+                    Command="{Binding Player.PlayCommand}"
+                    Content="再生" />
 
-            <Button
-                Grid.Row="0"
-                Grid.Column="1"
-                Command="{Binding Player.StopCommand}"
-                Content="停止" />
+                <Button
+                    Width="80"
+                    Margin="3,1"
+                    Command="{Binding Player.StopCommand}"
+                    Content="停止" />
 
-            <ListView
+            </StackPanel>
+
+            <StackPanel
                 Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                ItemsSource="{Binding Player.FileList}"
-                SelectedIndex="{Binding Player.SelectedFileIndex}"
-                SelectedItem="{Binding Player.SelectedFile}">
-
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel>
-                            <TextBlock Text="{Binding Name}" />
-                        </StackPanel>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                HorizontalAlignment="Right"
+                Orientation="Horizontal" />
 
         </Grid>
 
         <ListView
-            Grid.Row="1"
+            Grid.Row="2"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            ItemsSource="{Binding Player.FileList}"
+            SelectedIndex="{Binding Player.SelectedFileIndex}"
+            SelectedItem="{Binding Player.SelectedFile}">
+
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Name}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+
+        <ListView
+            Grid.Row="2"
             Grid.Column="1"
             ItemsSource="{Binding Player.Texts}"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled">

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -83,6 +83,7 @@
                 <Button
                     Width="100"
                     Margin="3,0"
+                    Command="{Binding Player.PlayFromIndexCommand}"
                     Content="指定行へジャンプ" />
 
                 <TextBox

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -76,8 +76,28 @@
 
             <StackPanel
                 Grid.Row="1"
+                Margin="1,0"
                 HorizontalAlignment="Right"
-                Orientation="Horizontal" />
+                Orientation="Horizontal">
+
+                <Button
+                    Width="100"
+                    Margin="3,0"
+                    Content="指定行へジャンプ" />
+
+                <TextBox
+                    Width="50"
+                    Text="{Binding Player.SelectedTextIndex}"
+                    TextAlignment="Center" />
+
+                <TextBlock Margin="5,0" Text="/" />
+
+                <TextBlock
+                    Width="50"
+                    Text="{Binding Player.Texts.Count}"
+                    TextAlignment="Center" />
+
+            </StackPanel>
 
         </Grid>
 

--- a/HTMLReaderCS/models/HTMLPlayer.cs
+++ b/HTMLReaderCS/models/HTMLPlayer.cs
@@ -113,6 +113,14 @@ namespace HTMLReaderCS.models
             ));
         }
 
+        public DelegateCommand PlayFromIndexCommand {
+            #region
+            get => playFromIndexCommand ?? (playFromIndexCommand = new DelegateCommand(() => {
+            }));
+        }
+        private DelegateCommand playFromIndexCommand;
+        #endregion
+
         private DelegateCommand stopCommand;
         public DelegateCommand StopCommand {
             get => stopCommand ?? (stopCommand = new DelegateCommand(

--- a/HTMLReaderCS/models/IPlayer.cs
+++ b/HTMLReaderCS/models/IPlayer.cs
@@ -17,6 +17,7 @@ namespace HTMLReaderCS.models {
         List<string> Texts { get; }
 
         DelegateCommand PlayCommand { get; }
+        DelegateCommand PlayFromIndexCommand { get; }
         DelegateCommand StopCommand { get; }
 
         void resetFiles();

--- a/HTMLReaderCS/models/TextBoxNumericBehavior.cs
+++ b/HTMLReaderCS/models/TextBoxNumericBehavior.cs
@@ -1,0 +1,71 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace HTMLReaderCS.Models {
+
+    /// <summary>
+    /// TextBox 添付ビヘイビア
+    /// </summary>
+    public class TextBoxNumericBehavior {
+
+        /// <summary>
+        /// True なら入力を数字のみに制限します。
+        /// </summary>
+        public static readonly DependencyProperty IsNumericProperty =
+                    DependencyProperty.RegisterAttached(
+                        "IsNumeric", typeof(bool),
+                        typeof(TextBoxNumericBehavior),
+                        new UIPropertyMetadata(false, IsNumericChanged)
+                    );
+
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        public static bool GetIsNumeric(DependencyObject obj) {
+            return (bool)obj.GetValue(IsNumericProperty);
+        }
+
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        public static void SetIsNumeric(DependencyObject obj, bool value) {
+            obj.SetValue(IsNumericProperty, value);
+        }
+
+        private static void IsNumericChanged
+            (DependencyObject sender, DependencyPropertyChangedEventArgs e) {
+
+            var textBox = sender as TextBox;
+            if (textBox == null) return;
+
+            // イベントを登録・削除 
+            textBox.KeyDown -= OnKeyDown;
+            textBox.TextChanged -= OnTextChanged;
+            var newValue = (bool)e.NewValue;
+            if (newValue) {
+                textBox.KeyDown += OnKeyDown;
+                textBox.TextChanged += OnTextChanged;
+            }
+        }
+
+        static void OnKeyDown(object sender, KeyEventArgs e) {
+            var textBox = sender as TextBox;
+            if (textBox == null) return;
+
+            if ((Key.D0 <= e.Key && e.Key <= Key.D9) ||
+                (Key.NumPad0 <= e.Key && e.Key <= Key.NumPad9) ||
+                (Key.Delete == e.Key) || (Key.Back == e.Key) || (Key.Tab == e.Key)) {
+                e.Handled = false;
+            }
+            else {
+                e.Handled = true;
+            }
+        }
+
+        private static void OnTextChanged(object sender, TextChangedEventArgs e) {
+            var textBox = sender as TextBox;
+            if (textBox == null) return;
+
+            if (string.IsNullOrEmpty(textBox.Text)) {
+                textBox.Text = "0";
+            }
+        }
+    }
+}

--- a/HTMLReaderCS/models/TextPlayer.cs
+++ b/HTMLReaderCS/models/TextPlayer.cs
@@ -127,6 +127,19 @@ namespace HTMLReaderCS.models
             ));
         }
 
+        public DelegateCommand PlayFromIndexCommand {
+            #region
+            get => playFromIndexCommand ?? (playFromIndexCommand = new DelegateCommand(() => {
+                if(SelectedTextIndex < Texts.Count) {
+                    talker.stop();
+                    PlayingLineNumber = SelectedTextIndex;
+                    PlayCommand.Execute();
+                }
+            }));
+        }
+        private DelegateCommand playFromIndexCommand;
+        #endregion
+
         private DelegateCommand stopCommand;
         public DelegateCommand StopCommand {
             get => stopCommand ?? (stopCommand = new DelegateCommand(


### PR DESCRIPTION
- ステータス表示のためにビューの配置、構造を変更
- 選択中の行数、選択中のファイルの行数、行ジャンプボタンを追加
- 行番号テキストボックスを数値のみ入力可能なよう制限
- IPlayer の実装クラスに、任意の行数から音声を再生するコマンドを追加

close #33
