### PR TITLE
20210522#37 次を再生ボタンの実装

### DIFF
--- a/HTMLReaderCS/ViewModels/MainWindowViewModel.cs
+++ b/HTMLReaderCS/ViewModels/MainWindowViewModel.cs
@@ -30,6 +30,18 @@ namespace HTMLReaderCS.ViewModels
             dialogService = _dialogService;
         }
 
+
+        public DelegateCommand PlayNextCommand {
+            #region
+            get => playNextCommand ?? (playNextCommand = new DelegateCommand(() => {
+                Player.StopCommand.Execute();
+                Player.PlayingIndex++;
+                Player.PlayCommand.Execute();
+            }));
+        }
+        private DelegateCommand playNextCommand;
+        #endregion
+
         public DelegateCommand ResetFileListCommand {
             #region
             get => resetFileListCommand ?? (resetFileListCommand = new DelegateCommand(() => {

--- a/HTMLReaderCS/Views/MainWindow.xaml
+++ b/HTMLReaderCS/Views/MainWindow.xaml
@@ -76,6 +76,12 @@
                     Command="{Binding Player.StopCommand}"
                     Content="停止" />
 
+                <Button
+                    Width="80"
+                    Margin="3,1"
+                    Command="{Binding PlayNextCommand}"
+                    Content="次の行を再生" />
+
             </StackPanel>
 
             <StackPanel

--- a/HTMLReaderCS/models/HTMLPlayer.cs
+++ b/HTMLReaderCS/models/HTMLPlayer.cs
@@ -21,7 +21,7 @@ namespace HTMLReaderCS.models
 
         public AzureSSMLGen SSMLConverter { get; } = new AzureSSMLGen();
 
-        private int PlayingIndex { get; set; } = 0;
+        public int PlayingIndex { get; set; } = 0;
         public String PlayingPlainText { get; private set; } = "";
 
         private OutputFileInfo outputFileInfo;

--- a/HTMLReaderCS/models/IPlayer.cs
+++ b/HTMLReaderCS/models/IPlayer.cs
@@ -13,6 +13,7 @@ namespace HTMLReaderCS.models {
         FileInfo SelectedFile { get; set; }
         int SelectedFileIndex { get; set; }
         int SelectedTextIndex { get; set; }
+        int PlayingIndex { get; set; }
 
         List<string> Texts { get; }
 


### PR DESCRIPTION
- IPlayer に 再生中のテキストのインデックスを表すプロパティを追加
- 次の文章を再生する機能を実装

任意行数後を読み上げる機能は必要無いと判断したので未実装。
次の行を読み上げる機能だけ実装

close #37
